### PR TITLE
Remove missed imports from 'co'

### DIFF
--- a/plop-templates/ava-test.js
+++ b/plop-templates/ava-test.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import co from 'co';
 import path from 'path';
 import AvaTest from './_base-ava-test';
 const {test, mockPath, testSrcPath, nodePlop} = (new AvaTest(__filename));
@@ -7,7 +6,7 @@ const {test, mockPath, testSrcPath, nodePlop} = (new AvaTest(__filename));
 const plop = nodePlop();
 
 /////
-// 
+//
 //
 
 test('{{sentenceCase name}} async test', async function (t) {

--- a/tests/_base-ava-test.js
+++ b/tests/_base-ava-test.js
@@ -1,7 +1,6 @@
 import ava from 'ava';
 import path from 'path';
 import del from 'del';
-import co from 'co';
 import * as fspp from '../lib/fs-promise-proxy.js';
 import nodePlop from '../lib/index.js';
 import { normalizePath } from '../src/actions/_common-action-utils';

--- a/tests/abort-on-fail.ava.js
+++ b/tests/abort-on-fail.ava.js
@@ -1,4 +1,3 @@
-import co from 'co';
 import AvaTest from './_base-ava-test';
 const {test, nodePlop} = (new AvaTest(__filename));
 

--- a/tests/action-data-cleanup.ava.js
+++ b/tests/action-data-cleanup.ava.js
@@ -1,4 +1,3 @@
-import co from 'co';
 import AvaTest from './_base-ava-test';
 const { test, testSrcPath, nodePlop } = new AvaTest(__filename);
 import { normalizePath } from '../src/actions/_common-action-utils';

--- a/tests/action-force-add.ava.js
+++ b/tests/action-force-add.ava.js
@@ -1,8 +1,6 @@
 import * as fspp from '../src/fs-promise-proxy';
-import co from 'co';
-import path from 'path';
 import AvaTest from './_base-ava-test';
-const {test, mockPath, testSrcPath, nodePlop} = (new AvaTest(__filename));
+const {test, testSrcPath, nodePlop} = (new AvaTest(__filename));
 
 /////
 // global and local "force" flag that can be used to push through failures

--- a/tests/add-action-binary-file.ava.js
+++ b/tests/add-action-binary-file.ava.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import co from 'co';
 import path from 'path';
 import AvaTest from './_base-ava-test';
 const {test, mockPath, testSrcPath, nodePlop} = (new AvaTest(__filename));

--- a/tests/add-action-executable-file.ava.js
+++ b/tests/add-action-executable-file.ava.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import co from 'co';
 import AvaTest from './_base-ava-test';
 const { test, mockPath, testSrcPath, nodePlop } = new AvaTest(__filename);
 

--- a/tests/add-action-failure.ava.js
+++ b/tests/add-action-failure.ava.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import co from 'co';
 import path from 'path';
 import AvaTest from './_base-ava-test';
 const {test, testSrcPath, nodePlop} = (new AvaTest(__filename));

--- a/tests/add-action-no-template.ava.js
+++ b/tests/add-action-no-template.ava.js
@@ -1,5 +1,4 @@
 import * as fspp from '../src/fs-promise-proxy';
-import co from 'co';
 import path from 'path';
 import AvaTest from './_base-ava-test';
 const {test, testSrcPath, nodePlop} = (new AvaTest(__filename));

--- a/tests/addMany-non-verbose.ava.js
+++ b/tests/addMany-non-verbose.ava.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import co from 'co';
 import path from 'path';
 import AvaTest from './_base-ava-test';
 const { test, mockPath, testSrcPath, nodePlop } = (new AvaTest(__filename));

--- a/tests/append-empty.ava.js
+++ b/tests/append-empty.ava.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import co from 'co';
 import AvaTest from './_base-ava-test';
 const {test, mockPath, testSrcPath, nodePlop} = new AvaTest(__filename);
 

--- a/tests/append.ava.js
+++ b/tests/append.ava.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import co from 'co';
 import AvaTest from './_base-ava-test';
 const {test, mockPath, testSrcPath, nodePlop} = new AvaTest(__filename);
 

--- a/tests/custom-data-in-actions.ava.js
+++ b/tests/custom-data-in-actions.ava.js
@@ -1,6 +1,5 @@
 // import fs from 'fs';
 import * as fspp from '../src/fs-promise-proxy';
-import co from 'co';
 import path from 'path';
 import AvaTest from './_base-ava-test';
 const {test, mockPath, testSrcPath, nodePlop} = (new AvaTest(__filename));

--- a/tests/dynamic-prompts.ava.js
+++ b/tests/dynamic-prompts.ava.js
@@ -1,4 +1,3 @@
-import co from 'co';
 import AvaTest from './_base-ava-test';
 const {test, mockPath, nodePlop} = (new AvaTest(__filename));
 

--- a/tests/force-del-outside-cwd.ava.js
+++ b/tests/force-del-outside-cwd.ava.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import co from 'co';
 import AvaTest from './_base-ava-test';
 const {test, mockPath, testSrcPath, nodePlop} = (new AvaTest(__filename));
 

--- a/tests/generator-name-and-prompts.ava.js
+++ b/tests/generator-name-and-prompts.ava.js
@@ -1,4 +1,3 @@
-import co from 'co';
 import AvaTest from './_base-ava-test';
 const {test, nodePlop} = (new AvaTest(__filename));
 

--- a/tests/imported-custom-action.ava.js
+++ b/tests/imported-custom-action.ava.js
@@ -1,5 +1,4 @@
 import {fileExists} from '../src/fs-promise-proxy';
-import co from 'co';
 import path from 'path';
 import AvaTest from './_base-ava-test';
 const {test, mockPath, testSrcPath, nodePlop} = (new AvaTest(__filename));

--- a/tests/lifecycle-hooks.ava.js
+++ b/tests/lifecycle-hooks.ava.js
@@ -1,6 +1,5 @@
-import co from 'co';
 import AvaTest from './_base-ava-test';
-const {test, testSrcPath, nodePlop} = (new AvaTest(__filename));
+const {test, nodePlop} = (new AvaTest(__filename));
 
 const errAction = () => {throw Error('');};
 

--- a/tests/load-assets-from-plopfile.ava.js
+++ b/tests/load-assets-from-plopfile.ava.js
@@ -1,5 +1,4 @@
 // import fs from 'fs';
-// import co from 'co';
 import path from 'path';
 import AvaTest from './_base-ava-test';
 const {test, mockPath, nodePlop} = (new AvaTest(__filename));

--- a/tests/load-nested-plopfile-generators.ava.js
+++ b/tests/load-nested-plopfile-generators.ava.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import co from 'co';
 import path from 'path';
 import AvaTest from './_base-ava-test';
 const {test, mockPath, testSrcPath, nodePlop} = (new AvaTest(__filename));

--- a/tests/missing-action-path.ava.js
+++ b/tests/missing-action-path.ava.js
@@ -1,4 +1,3 @@
-import co from 'co';
 import AvaTest from './_base-ava-test';
 const {test, nodePlop} = (new AvaTest(__filename));
 


### PR DESCRIPTION
After #150, we were left with some un-needed imports to `co` missed by the codemod. This fixes that by removing them (the codemod DID migrate the related code so they're not required anymore)