### PR TITLE
Bugfixes for skip function

### DIFF
--- a/src/generator-runner.js
+++ b/src/generator-runner.js
@@ -116,9 +116,15 @@ export default function (plopfileApi, flags) {
 
 		// check if action should run
 		if (typeof cfg.skip === 'function') {
+			// Merge main data and config data in new object
 			const reasonToSkip = await cfg.skip({ ...data, ...cfgData });
+			
 			if (typeof reasonToSkip === 'string') {
-				return reasonToSkip;
+				// Return actionResult instead of string
+				return {
+					type: 'skip',
+					path: reasonToSkip
+				};
 			}
 		}
 

--- a/src/generator-runner.js
+++ b/src/generator-runner.js
@@ -116,7 +116,7 @@ export default function (plopfileApi, flags) {
 
 		// check if action should run
 		if (typeof cfg.skip === 'function') {
-			const reasonToSkip = await cfg.skip(data);
+			const reasonToSkip = await cfg.skip({ ...data, ...cfgData });
 			if (typeof reasonToSkip === 'string') {
 				return reasonToSkip;
 			}

--- a/tests/add-action-skip-function.ava.js
+++ b/tests/add-action-skip-function.ava.js
@@ -36,6 +36,7 @@ test.serial('action runs as expected without skip function', async function(t) {
 
 	// Check action ran ok
 	t.true(results.changes.length === 1, 'action was skipped');
+	t.not(results.changes[0].type, 'skip', 'type should not be skip');
 	t.true(results.failures.length === 0, 'action failed');
 
 	// Check that the file was not created
@@ -131,6 +132,7 @@ test.serial('action executes if skip function returns void', async function(t) {
 
 	// Check action ran ok
 	t.true(results.changes.length > 0, 'action was skipped');
+	t.not(results.changes[0].type, 'skip', 'type should not be skip');
 	t.true(results.failures.length === 0, 'action failed');
 
 	// Check that the file was created
@@ -155,7 +157,8 @@ test.serial('action skips if async skip function returns a string', async functi
 
 	// Check action ran ok
 	t.true(results.changes.length > 0, 'action was not skipped');
-	t.true(results.changes[0] === message, 'message was not used');
+	t.is(results.changes[0].type, 'skip', 'type should be "skip"');
+	t.true(results.changes[0].path === message, 'message was not used');
 	t.true(results.failures.length === 0, 'action failed');
 
 	// Check that the file was not created
@@ -203,7 +206,8 @@ test.serial('action skips if skip function returns a string', async function(t) 
 
 	// Check action ran ok
 	t.true(results.changes.length > 0, 'action was not skipped');
-	t.true(results.changes[0] === message, 'message was not used');
+	t.is(results.changes[0].type, 'skip', 'type is not skip');
+	t.true(results.changes[0].path === message, 'message was not used');
 	t.true(results.failures.length === 0, 'there were one or more failures');
 
 	// Check that the file was not created

--- a/tests/add-action-skip-function.ava.js
+++ b/tests/add-action-skip-function.ava.js
@@ -66,21 +66,26 @@ test.serial('action throws if action.skip is not a function', async function(
 });
 
 test.serial('skip function receives correct arguments', async function(t) {
+	const mainData = { fileName, a: 1 };
+	const configData = { a: 'a', b: 2 };
+	
 	const action = plop.setGenerator(genName, {
 		actions: [
 			{
 				...addAction,
 				async skip(...args) {
 					t.is(args.length, 1);
-					t.deepEqual(args[0], { name: fileName });
+					// Main data should be overwritten by config data
+					t.deepEqual(args[0], {...mainData, ...configData});
 
 					return 'Just checking arguments';
-				}
+				},
+				data: configData
 			}
 		]
 	});
 
-	await action.runActions({ name: fileName });
+	await action.runActions(mainData);
 });
 
 test.serial(


### PR DESCRIPTION
This fixes two bugs related to the new `skip` function.

1. Previously `skip` only received data from the main data scope. Now skip is called with data from both the action config and the main data object. If there is a collision, data from the action config overwrites the main data object.
2. Previously `skip` returned a string. This caused some unusual behavior on the CLI. Now skip returns an ActionResult with type of `"skip"`.

This PR pairs with https://github.com/plopjs/plop/pull/202