### PR TITLE
Fix type bug in modify action

### DIFF
--- a/src/actions/modify.js
+++ b/src/actions/modify.js
@@ -26,7 +26,11 @@ export default async function (data, cfg, plop) {
 			let fileData = await fspp.readFile(fileDestPath);
 			cfg.templateFile = getRenderedTemplatePath(data, cfg, plop);
 			const replacement = await getRenderedTemplate(data, cfg, plop);
-			fileData = fileData.replace(cfg.pattern, replacement);
+
+			if (typeof cfg.pattern === 'string' || cfg.pattern instanceof RegExp) {
+				fileData = fileData.replace(cfg.pattern, replacement);
+			}
+
 			const transformed = await getTransformedTemplate(fileData, data, cfg);
 			await fspp.writeFile(fileDestPath, transformed);
 		}

--- a/tests/modify-action-transform-function.ava.js
+++ b/tests/modify-action-transform-function.ava.js
@@ -267,3 +267,27 @@ test.serial(
 		t.true(changes.length === 1, 'modify action made changes');
 	}
 );
+
+test.serial(
+	'Modify action without pattern does not remove "undefined"',
+	async function(t) {
+		const template = 'type SomeType = string | undefined;';
+		
+		const gen = plop.setGenerator(genName, {
+			actions: [
+				{...addAction, template },
+				{
+					...modifyAction,
+					async transform(code) {
+						t.true(/undefined/.test(code), 'modify action removed "undefined"');
+						return code;
+					}
+				}]
+		});
+
+		const { changes, failures } = await gen.runActions({ fileName });
+
+		t.true(failures.length === 0, 'an action failed');
+		t.true(changes.length === 2, 'not enough change were made');
+	}
+);


### PR DESCRIPTION
Fixes https://github.com/plopjs/plop/issues/205

The modify action was removing instances of "undefined" from modified files when the transform function was used without the pattern property.