### PR TITLE
Improve typings, fix type errors

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -111,23 +111,29 @@ export interface ActionConfig {
 	force?: boolean;
 	data?: object;
 	abortOnFail?: boolean;
+	skip?: Function;
 }
+
+type TranformFn<T> = (template: string, data: any, cfg: T) => string | Promise<string>;
 
 export interface AddActionConfig extends ActionConfig {
 	type: 'add';
 	path: string;
 	template: string;
 	templateFile: string;
-	skipIfExists: boolean;
+	skipIfExists?: boolean;
+	transform?: TranformFn<AddActionConfig>;
 }
 
-export interface AddManyActionConfig extends Pick<AddActionConfig, Exclude<keyof AddActionConfig, 'type'>> {
+export interface AddManyActionConfig extends Pick<AddActionConfig, Exclude<keyof AddActionConfig, 'type' | 'templateFile' | 'template' | 'transform'>> {
 	type: 'addMany';
 	destination: string;
 	base: string;
-	templateFiles: string;
+	templateFiles: string | string[];
+	stripExtensions?: string[];
 	globOptions: GlobOptions;
-	verbose: boolean;
+	verbose?: boolean;
+	transform?: TranformFn<AddManyActionConfig>;
 }
 
 export interface ModifyActionConfig extends ActionConfig {
@@ -136,6 +142,7 @@ export interface ModifyActionConfig extends ActionConfig {
 	pattern: string | RegExp;
 	template: string;
 	templateFile: string;
+	transform?: TranformFn<ModifyActionConfig>;
 }
 
 export interface AppendActionConfig extends ActionConfig {

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,4 +1,4 @@
-import nodePlop from './index';
+import nodePlop, {AddManyActionConfig} from './index';
 
 const plop = nodePlop('./file', {
 	destBasePath: './',
@@ -101,3 +101,28 @@ plop.setGenerator("test-dynamic-prompts-and-actions", {
 		}];
 	}
 })
+
+const useAddManyAction = (): AddManyActionConfig => ({
+	type: 'addMany',
+	base: '',
+	templateFiles: '',
+	path: '',
+	destination: '',
+	stripExtensions: ['hbs'],
+	globOptions: {
+		dot: true
+	},
+});
+
+const useAddManyTransformAction = (): AddManyActionConfig => ({
+	type: 'addMany',
+	base: '',
+	templateFiles: '',
+	path: '',
+	destination: '',
+	stripExtensions: ['hbs'],
+	transform: () => 'hello',
+	globOptions: {
+		dot: true
+	},
+});


### PR DESCRIPTION
This PR makes the typings match the documentation.

Additional to adding `templateFiles` array of string support and `stripExtension`, it also fixes various required fields and adds the documented `transform` property

Closes #177, https://github.com/plopjs/plop/issues/225