### PR TITLE
Fix: Property 'path' does not exist on type 'ActionConfig'.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -94,7 +94,7 @@ export type Actions = DynamicActionsFunction | ActionType[];
 
 export type CustomActionFunction = (
 	answers: object,
-	config?: ActionConfig,
+	config?: AddActionConfig,
 	plopfileApi?: NodePlopAPI
 ) => Promise<string> | string; // Check return type?
 


### PR DESCRIPTION
exmple code:
```ts
import { NodePlopAPI } from 'plop';
import { ESLint } from 'eslint';

module.exports = (plop: NodePlopAPI) => {
  plop.setActionType('formatCode', async (answers, config, plopInstance) => {
    if (config && config.path && plopInstance) {
      const filePath = plopInstance.renderString(config.path, answers);
      const eslint = new ESLint({ fix: true });
      const results = await eslint.lintFiles([...filePath.split(',')]);

      await ESLint.outputFixes(results);

      return 'code formatted';
    }

    throw new Error('Formatting skipped');
  });
...
});
```
![image](https://user-images.githubusercontent.com/468006/100024034-b9f15780-2dee-11eb-9f6f-37912a234099.png)
