### PR TITLE
Add mising comma to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 // Used by eslint for linting
 {
-	"extends": "./types/tsconfig.json"
+	"extends": "./types/tsconfig.json",
 	// We're just using this for index.d.ts
 	"include": [
 	  "types/index.d.ts",


### PR DESCRIPTION
The tsconfig.json was missing a comma causing errors when trying to use the API via [esbuild-node-loader](https://github.com/antfu/esbuild-node-loader).